### PR TITLE
remove commented import statement to workaround error of 'go get' from github

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -12,4 +12,4 @@
 //implement the Limiter interface, allowing consumers to treat its encapsulated
 //group of Limiters as a single Limiter, knowing the strategy will be applied
 //within the given limits.
-package limio // import "astuart.co/limio"
+package limio


### PR DESCRIPTION
remove commented import statement to workaround error of 'go get' from github